### PR TITLE
Include Bluetooth in required packages as well as clarify some instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,9 @@ Many thanks to *Kai Krakow* who **sponsored** me a Xbox One Wireless Controller 
 ## Getting started
 ### Prerequisites
 Make sure you have installed the following packages and their dependencies
-* dkms
-* linux-headers
+* `dkms`
+* `linux-headers`
+* `bluez` and `bluez-utils`
 
 On **Debian** based systems (like Ubuntu) you can install those packages by running  
 ``sudo apt-get install dkms linux-headers-`uname -r` ``  
@@ -36,7 +37,8 @@ On **Arch** and similar distros (like Antergos), try
 ### Installation
 * Download the Repository to your local machine 
   `git clone https://github.com/atar-axis/xpadneo.git`
-* Run the `install.sh` script
+* `cd xpadneo`
+* Run `./install.sh`
 * Done!
 
 ### Connection

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ On **Debian** based systems (like Ubuntu) you can install those packages by runn
 On **Raspbian**, it is  
 `sudo apt-get install dkms raspberrypi-kernel-headers`  
 On **Arch** and similar distros (like Antergos), try  
-`sudo pacman -S dkms linux-headers`
+`sudo pacman -S dkms linux-headers bluez bluez-utils`
 
 ### Installation
 * Download the Repository to your local machine 


### PR DESCRIPTION
I had to help someone who didn't know much install this. These were the changes that would have helped make it a little easier for them to understand.

Bluetooth isn't something that is installed by default on arch and, apparently, the AUR package doesn't require bluetooth, which was a bit of a hitch in installing it. Thankfully it wasn't that difficult to solve beyond installing it.