### PR TITLE
Document how to get xpadneo to work with Secure Boot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,10 +17,7 @@ and add at least the following outputs
 - `dmesg`
 
 The following command need superuser privileges.
-I recommend to run it as root directly (do not use `sudo`),
-otherwise the auto-completion using <TAB> will not work as expected.
-
-- `head -1 "/sys/kernel/debug/hid/0005:045E:<TAB>/rdesc" | tee /dev/tty | cksum`
+- `sudo find "/sys/kernel/debug/hid/" -name "0005:045E:*" -exec sh -c 'echo "{}" && head -1 "{}/rdesc" | tee /dev/tty | cksum && echo' \;`
 
 **Additional context**  
 Add any other context about the problem here.

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -19,3 +19,13 @@ echo "options hid_xpadneo debug_level=3" | sudo tee /etc/modprobe.d/xpadneo.conf
 ```
 
 Now, the driver will be initialized with debug level 3 during modprobe.
+
+Useful information can now be aquired with the commands:
+
+* `dmesg`: I advise you to run `dmesg -wH` in a terminal while you connect your controller from a second terminal to get hardware information in realtime.
+* `modinfo hid_xpadneo`: get information on xpadneo as a kernel module.
+* When your gamepad is connected, run
+  ```console
+  sudo find "/sys/kernel/debug/hid/" -name "0005:045E:*" -exec sh -c 'echo "{}" && head -1 "{}/rdesc" | tee /dev/tty | cksum && echo' \;
+  ```
+  to get the rdesc identifier of your gamepad.

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,13 @@ Please feel free to add other Distributions as well!
 
 You know that everything works fine when you feel the gamepad rumble ;)
 
+> **The gamepad did not rumble ?** Secure Boot may be enabled on your computer. On most Linux distribution, running `mokutil --sb-state` will tell you if it is the case. When Secure Boot is enabled, unsigned kernel module cannot be loaded. Two options are available:
+> 1. Disable Secure Boot.
+> 2. Sign the module yourself.
+> Instructions for both of these options are available [here](https://atar-axis.github.io/xpadneo/#working-with-secure-boot).
+>
+> Secure Boot is not enabled and pairing still fails? See [Debugging](https://atar-axis.github.io/xpadneo/#debugging).
+
 ### Configuration
 The driver can be reconfigured at runtime by accessing the following sysfs
 files in `/sys/module/hid_xpadneo/parameters`:

--- a/docs/SECUREBOOT.md
+++ b/docs/SECUREBOOT.md
@@ -1,0 +1,62 @@
+## Working with Secure Boot
+
+Secure Boot is a verification mechanism used when your computer loads your operating system. The boot  process of a Linux distribution usually goes like this: [UEFI](https://help.ubuntu.com/community/UEFI) -> [UEFI Shim loader](https://www.rodsbooks.com/efi-bootloaders/secureboot.html#shim) -> your distribution.
+Now back to our two options: disabling Secure Boot or signing xpadneo with your own key.
+
+### Disabling Secure Boot
+
+In order for Secure Boot to be active, it must be enabled both at the UEFI level and at the shim level. Which means you should be able to disable Secure Boot:
+
+* either in your firmware options. You can usually access them by pressing F1, F2 or F12 justa after turning on the computer.
+* or in the shim. Run `sudo mokutil --disable-validation`, and choose a password. Reboot your computer. You will be asked if you really want to disable Secure Boot. Press `Yes` and enter the password. You can now safely forget the password.
+
+After choosing either of these two options, Secure Boot should be disabled. You may therefore try to connect your Xbox One gamepad.
+
+### Signing xpadneo with your own keys
+
+If you do not wish to disable Secure Boot, you will need to get the Shim to trust xpadneo. The process goes this way:
+
+* generate a cryptographic key pair: a private key and a public key
+* sign the module with your private key
+* get the shim to trust your public key
+
+Xpadneo will need to be re-signed every time it is updated, and every time the kernel is updated. To simplify this process, we provide scripts which will help you generate your keys and automatically sign xpadneo when needed.
+
+```console
+cd xpadneo
+# Xpadneo will be signed each time it is installed, you should therefore uninstall it now if needed!
+sudo ./uninstall.sh
+
+# Copy a directory containing three helper scripts in the /root directory
+sudo cp -r misc/module-signing /root
+
+# Generate the keys and ask the shim to trust them.
+# They will be saved as /root/module-signing/MOK.der (public key) and /root/module-signing/MOK.priv (private key)
+# You will be asked to choose a password. This password will only be needed one time, just after the reboot.
+sudo /root/module-signing/one-time-setup
+
+# READ THIS BEFORE REBOOTING:
+# Just after rebooting, you will be prompted to press a key to enter the Shim. Press any key, then select the `Enroll key` option. You will get a chance to review the key that you are about to trust. To accept the key, select Yes then enter the password you chose previously.
+# /!\ WARNING: The keyboard layout used to type the password will be QWERTY, no matter what keyboard you use.
+
+# Choose `Continue` to boot into your operating system.
+# Your public key is now trusted by the shim.
+
+# Ask DKMS to sign Xpadneo when needed.
+echo "POST_BUILD=../../../../../../root/module-signing/dkms-sign-module" | sudo tee "/etc/dkms/hid_xpadneo"
+
+# Go back to the xpadneo folder and install the module. It will be signed automatically.
+cd xpadneo
+sudo ./install.sh
+```
+
+Notes:
+
+* if in the future you wish to remove your public key from the shim, run
+
+   ```console
+   sudo mokutil --delete "/root/module-signing/MOK.der"
+   ```
+
+   Reboot, and follow the procedure.
+* using theses scripts, your private key will be kept unencrypted in the `/root` directory. This may pose a security risk. If you wish to password protect your private keys, use [these scripts, written by dop3j0e](https://gist.github.com/dop3j0e/2a9e2dddca982c4f679552fc1ebb18df). Be warned that you will be asked for your password every time the kernel gets an update.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 {% include_relative README.md %}
 {% include_relative DEBUGGING.md %}
+{% include_relative SECUREBOOT.md %}
 {% include_relative 3P-BUGS.md %}
 {% include_relative SDL.md %}

--- a/misc/module-signing/dkms-sign-module
+++ b/misc/module-signing/dkms-sign-module
@@ -1,0 +1,4 @@
+#!/bin/bash
+export PROMPT="Enter Machine Owner Key (MOK) passphrase to sign $module $module_version: "
+export KERNELVER=$kernelver
+$(dirname $0)/sign-modules ../$kernelver/$arch/module/*.ko*

--- a/misc/module-signing/one-time-setup
+++ b/misc/module-signing/one-time-setup
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+mydir=$(dirname $0)
+
+echo "I am about to generate the Machine Owner Key (MOK)."
+read -p "Please press Return to go on..."
+openssl req -new -x509 -nodes -newkey rsa:2048 -keyout $mydir/MOK.priv -outform DER -out $mydir/MOK.der -days 36500 -subj "/CN=$(hostname) module signing key/" || exit 1
+
+echo
+echo "Now I will import the generated key into the secure keystore."
+echo "The passphrase you will enter is only required once, during the following reboot."
+read -p "Please press Return to go on..."
+mokutil --import $mydir/MOK.der || exit 1
+
+echo
+echo "Please reboot your computer now to complete the enrollment of your new MOK."
+echo "This is going to look somewhat similar to https://sourceware.org/systemtap/wiki/SecureBoot"

--- a/misc/module-signing/sign-modules
+++ b/misc/module-signing/sign-modules
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [[ -z "$1" ]]; then
+    echo "Usage: $0 module [module...]"
+    exit 1
+fi
+
+mydir=$(dirname $0)
+
+KERNELVER=${KERNELVER:-$(uname -r)}
+
+do_sign() {
+    /lib/modules/$KERNELVER/build/scripts/sign-file sha256 $mydir/MOK.priv $mydir/MOK.der "$1"
+}
+
+for module in $@; do
+    echo "Signing module: $module"
+    module_basename=${module:0:-3}
+    module_suffix=${module: -3}
+    if [[ "$module_suffix" == ".xz" ]]; then
+	unxz $module
+	do_sign $module_basename
+	xz -f $module_basename
+    elif [[ "$module_suffix" == ".gz" ]]; then
+	gunzip $module
+	do_sign $module_basename
+	gzip -9f $module_basename
+    else
+	do_sign $module
+    fi    
+done


### PR DESCRIPTION
In this PR, I document how to make xpadneo and Secure Boot get along.
I added a small note to the README.md, and a longer description to a SECUREBOOT.md file which I included in index.md.
I also added the three helper scripts to the misc/ folder. They are modified so that signing is fully automatic (i.e. passwordless).

I wanted to make some modifications to DEBUGGING.md and bug_report.md in another PR, but since I already committed them to master I did not find how to split it in another PR...
My gripe was that 
- `head -1 "/sys/kernel/debug/hid/0005:045E:<TAB>/rdesc" | tee /dev/tty | cksum` could not be copy-pasted even when I ran it directly as root like you suggested. I think a command using `find` will be more robust.

Finally, I said that Secure Boot could not be disabled on ARM devices, but I found out that Secure Boot could always be disabled at the shim level using `mokutil --disable-validation`. This makes signing instructions nice-to-have but quite secondary.

Hope this helps ;)