### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ Make sure you have installed *dkms*, *linux headers* and a bluetooth implementat
 * On **Debian** based systems (like Ubuntu) you can install those packages by running  
   ``sudo apt-get install dkms linux-headers-`uname -r` ``  
 * On **Fedora**, it is  
-  ``sudo dnf install dkms bluez bluez-tools kernel-devel-`uname -r` kernel-headers-`uname -r` `` 
+  ``sudo dnf install dkms make bluez bluez-tools kernel-devel-`uname -r` kernel-headers-`uname -r` `` 
 * On **OSMC** you will have to run the following commands  
   ``sudo apt-get install dkms rbp2-headers-`uname -r` ``  
   ``sudo ln -s "/usr/src/rbp2-headers-`uname -r`" "/lib/modules/`uname -r`/build"`` (as a [workaround](https://github.com/osmc/osmc/issues/471))


### PR DESCRIPTION
Fedora additionally needs `make` for installation (which isn't a dependency of the other packages)
Otherwise you get

```
Building module:
cleaning build area...(bad exit status: 127)
make -j12 KERNELRELEASE=5.2.9-200.fc30.x86_64 -C /lib/modules/5.2.9-200.fc30.x86_64/build M=/var/lib/dkms/hid-xpadneo/0.6.0/build/src modules...(bad exit status: 127)
Error! Bad return status for module build on kernel: 5.2.9-200.fc30.x86_64 (x86_64)
Consult /
```

and the logfile says `make` is missing.