### PR TITLE
Fix build and debug print for kernel version >= 5.4

### DIFF
--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -82,7 +82,7 @@ MODULE_PARM_DESC(fake_dev_version, "(u16) Fake device version # to hide from SDL
 #define hid_dbg_lvl(lvl, fmt_hdev, fmt_str, ...) \
 	do { \
 		if (param_debug_level >= lvl) \
-			hid_printk(KERN_DEBUG, pr_fmt(fmt_hdev), \
+			hid_dbg(pr_fmt(fmt_hdev), \
 				pr_fmt(fmt_str), ##__VA_ARGS__); \
 	} while (0)
 #define dbg_hex_dump_lvl(lvl, fmt_prefix, data, size) \


### PR DESCRIPTION
Build was broken in 5.4. This should fix it.

I tested this on mainline 5.4-rc1 and it worked fine, haven't tested on anything else, but since the hid_dbg macro was not affected by the commit mentioned, it should work fine for older kernels as well.