### PR TITLE
Add Support For Xbox Elite Series 2 Wireless

### DIFF
--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -1337,6 +1337,7 @@ static const struct hid_device_id xpadneo_devices[] = {
 	/* XBOX ONE S / X */
 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, 0x02FD) },
 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, 0x02E0) },
+	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, 0x0B05) },
 	/* SENTINEL VALUE, indicates the end*/
 	{ }
 };

--- a/hid-xpadneo/src/udev_rules/99-xpadneo.rules
+++ b/hid-xpadneo/src/udev_rules/99-xpadneo.rules
@@ -19,11 +19,6 @@
 #                                                                                                                               02E0        automatic
 
 ACTION=="add", \
-KERNEL=="0005:045E:02FD.*|0005:045E:02E0.*", \
-SUBSYSTEM=="hid", \
-RUN:="/bin/sh -c 'echo xpadneo udev: $kernel > /dev/kmsg; modprobe hid_xpadneo; echo $kernel > /sys/bus/hid/drivers/hid-generic/unbind; echo $kernel > /sys/bus/hid/drivers/microsoft/unbind; echo $kernel > /sys/bus/hid/drivers/xpadneo/bind; echo xpadneo udev: ok > /dev/kmsg'"
-
-ACTION=="add", \
-KERNEL=="0005:045E:0B05.*|0005:045E:0B05.*", \
+KERNEL=="0005:045E:02FD.*|0005:045E:02E0.*|0005:045E:0B05.*", \
 SUBSYSTEM=="hid", \
 RUN:="/bin/sh -c 'echo xpadneo udev: $kernel > /dev/kmsg; modprobe hid_xpadneo; echo $kernel > /sys/bus/hid/drivers/hid-generic/unbind; echo $kernel > /sys/bus/hid/drivers/microsoft/unbind; echo $kernel > /sys/bus/hid/drivers/xpadneo/bind; echo xpadneo udev: ok > /dev/kmsg'"

--- a/hid-xpadneo/src/udev_rules/99-xpadneo.rules
+++ b/hid-xpadneo/src/udev_rules/99-xpadneo.rules
@@ -22,3 +22,8 @@ ACTION=="add", \
 KERNEL=="0005:045E:02FD.*|0005:045E:02E0.*", \
 SUBSYSTEM=="hid", \
 RUN:="/bin/sh -c 'echo xpadneo udev: $kernel > /dev/kmsg; modprobe hid_xpadneo; echo $kernel > /sys/bus/hid/drivers/hid-generic/unbind; echo $kernel > /sys/bus/hid/drivers/microsoft/unbind; echo $kernel > /sys/bus/hid/drivers/xpadneo/bind; echo xpadneo udev: ok > /dev/kmsg'"
+
+ACTION=="add", \
+KERNEL=="0005:045E:0B05.*|0005:045E:0B05.*", \
+SUBSYSTEM=="hid", \
+RUN:="/bin/sh -c 'echo xpadneo udev: $kernel > /dev/kmsg; modprobe hid_xpadneo; echo $kernel > /sys/bus/hid/drivers/hid-generic/unbind; echo $kernel > /sys/bus/hid/drivers/microsoft/unbind; echo $kernel > /sys/bus/hid/drivers/xpadneo/bind; echo xpadneo udev: ok > /dev/kmsg'"


### PR DESCRIPTION
For #142 

On my Fedora 31 system, this does get xpadneo working with my Xbox Elite Series 2 over Bluetooth. "udevadm info -a -n /dev/input/js0" and "hwinfo" both show that xpadneo is indeed the driver being used for gamepad.

I confirmed with evtest that every button on the gamepad generates events.

Are the control mappings right? No, but that should be fixed in userspace (using SDL2's controller mappings) and not in the kernel driver.