### PR TITLE
hid-xpadneo: Prevent accidental fall-through

### DIFF
--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -621,6 +621,7 @@ u8 map_hid_to_input_windows(struct hid_usage *usage, struct input_ev *map_to)
 			*map_to = (struct input_ev){EV_KEY, BTN_THUMBR};
 			return MAP_STATIC;
 		}
+		return MAP_IGNORE;
 	case HID_UP_GENDESK:
 		switch (hid_usage) {
 		case 0x30:
@@ -648,6 +649,7 @@ u8 map_hid_to_input_windows(struct hid_usage *usage, struct input_ev *map_to)
 			*map_to = (struct input_ev){EV_KEY, BTN_MODE};
 			return MAP_STATIC;
 		}
+		return MAP_IGNORE;
 	}
 
 	return MAP_IGNORE;
@@ -712,6 +714,7 @@ u8 map_hid_to_input_linux(struct hid_usage *usage, struct input_ev *map_to)
 			*map_to = (struct input_ev){EV_KEY, BTN_THUMBR};
 			return MAP_STATIC;
 		}
+		return MAP_IGNORE;
 	case HID_UP_CONSUMER:
 		switch (hid_usage) {
 		case 0x223:
@@ -721,6 +724,7 @@ u8 map_hid_to_input_linux(struct hid_usage *usage, struct input_ev *map_to)
 			*map_to = (struct input_ev){EV_KEY, BTN_SELECT};
 			return MAP_STATIC;
 		}
+		return MAP_IGNORE;
 	case HID_UP_GENDESK:
 		switch (hid_usage) {
 		case 0x30:
@@ -739,6 +743,7 @@ u8 map_hid_to_input_linux(struct hid_usage *usage, struct input_ev *map_to)
 			*map_to = (struct input_ev){0, 0};
 			return MAP_AUTO;
 		}
+		return MAP_IGNORE;
 	case HID_UP_SIMULATION:
 		switch (hid_usage) {
 		case 0xC4:
@@ -748,6 +753,7 @@ u8 map_hid_to_input_linux(struct hid_usage *usage, struct input_ev *map_to)
 			*map_to = (struct input_ev){EV_ABS, ABS_Z};
 			return MAP_STATIC;
 		}
+		return MAP_IGNORE;
 	}
 
 	return MAP_IGNORE;


### PR DESCRIPTION
Observation:

```
drivers/hid/hid-xpadneo.c: In Funktion »map_hid_to_input_windows«:
drivers/hid/hid-xpadneo.c:592:3: Warnung: diese Anweisung könnte durchfallen [-Wimplicit-fallthrough=]
  592 |   switch (hid_usage) {
      |   ^~~~~~
drivers/hid/hid-xpadneo.c:624:2: Anmerkung: hier
  624 |  case HID_UP_GENDESK:
      |  ^~~~
drivers/hid/hid-xpadneo.c: In Funktion »map_hid_to_input_linux«:
drivers/hid/hid-xpadneo.c:686:3: Warnung: diese Anweisung könnte durchfallen [-Wimplicit-fallthrough=]
  686 |   switch (hid_usage) {
      |   ^~~~~~
drivers/hid/hid-xpadneo.c:715:2: Anmerkung: hier
  715 |  case HID_UP_CONSUMER:
      |  ^~~~
drivers/hid/hid-xpadneo.c:716:3: Warnung: diese Anweisung könnte durchfallen [-Wimplicit-fallthrough=]
  716 |   switch (hid_usage) {
      |   ^~~~~~
drivers/hid/hid-xpadneo.c:724:2: Anmerkung: hier
  724 |  case HID_UP_GENDESK:
      |  ^~~~
drivers/hid/hid-xpadneo.c:725:3: Warnung: diese Anweisung könnte durchfallen [-Wimplicit-fallthrough=]
  725 |   switch (hid_usage) {
      |   ^~~~~~
drivers/hid/hid-xpadneo.c:742:2: Anmerkung: hier
  742 |  case HID_UP_SIMULATION:
      |  ^~~~
```

If none of the inner cases matches, the case will fall-through the next
outer case and may incorrectly apply mappings.

Please review because I don't know if this is intentional. If it is, we should hint the compiler with `/* fall-through */` instead.