### PR TITLE
Make sure /usr/sbin/modprobe is found in udev rule on Fedora

### DIFF
--- a/hid-xpadneo/src/udev_rules/99-xpadneo.rules
+++ b/hid-xpadneo/src/udev_rules/99-xpadneo.rules
@@ -21,4 +21,4 @@
 ACTION=="add", \
 KERNEL=="0005:045E:02FD.*|0005:045E:02E0.*", \
 SUBSYSTEM=="hid", \
-RUN:="/bin/sh -c 'echo xpadneo udev: $kernel > /dev/kmsg; modprobe hid_xpadneo; echo $kernel > /sys/bus/hid/drivers/hid-generic/unbind; echo $kernel > /sys/bus/hid/drivers/microsoft/unbind; echo $kernel > /sys/bus/hid/drivers/xpadneo/bind; echo xpadneo udev: ok > /dev/kmsg'"
+RUN:="/bin/sh -c 'echo xpadneo udev: $kernel > /dev/kmsg; if [ -d /usr/sbin ]; then PATH=$PATH:/usr/sbin; fi; modprobe hid_xpadneo; echo $kernel > /sys/bus/hid/drivers/hid-generic/unbind; echo $kernel > /sys/bus/hid/drivers/microsoft/unbind; echo $kernel > /sys/bus/hid/drivers/xpadneo/bind; echo xpadneo udev: ok > /dev/kmsg'"


### PR DESCRIPTION
The modprobe binary is not found when executing the udev rule on Fedora 31 since it is not on the PATH. This somewhat ugly fix checks if the /usr/sbin dir (location of modprobe) exists and appends it to the path if it does, ensuring modprobe is able to run. Probably the issue observed in #107 