### PR TITLE
Fix error "/var/lib/dkms/hid-xpadneo/0.7/source/dkms.post_install: 5: [: unexpected operator" when running install script

### DIFF
--- a/hid-xpadneo/dkms.post_install
+++ b/hid-xpadneo/dkms.post_install
@@ -2,7 +2,7 @@
 
 ERTM_OVERRIDE="/etc/modprobe.d/99-xpadneo-bluetooth.conf"
 
-if [ "$(readlink "${ERTM_OVERRIDE}")" == "/dev/null" ]; then
+if [ "$(readlink "${ERTM_OVERRIDE}")" = "/dev/null" ]; then
 	echo "Not disabling ERTM, local override in place..."
 elif [ -L "${ERTM_OVERRIDE}" ]; then
 	echo >&2 "WARNING: '${ERTM_OVERRIDE}' is an arbitrary symlink, this is not supported."


### PR DESCRIPTION
When running the install script, the following error is displayed:
`/var/lib/dkms/hid-xpadneo/0.7/source/dkms.post_install: 5: [: unexpected operator`

After analysing `dkms.post_install` with the `shellcheck` utility, the following error is found:
```
$ shellcheck /var/lib/dkms/hid-xpadneo/0.7/source/dkms.post_install

In /var/lib/dkms/hid-xpadneo/0.7/source/dkms.post_install line 5:
if [ "$(readlink "${ERTM_OVERRIDE}")" == "/dev/null" ]; then
                                      ^-- SC2039: In POSIX sh, == in place of = is undefined.
```

As stated in the relevant [shellcheck documentation of SC2039](https://github.com/koalaman/shellcheck/wiki/SC2039#testing-equality), `==` operator is not supported in POSIX `sh`, which is being used, as stated on the first "shebang" line of the script.

I have therefore modified the line containing the error in question, so that it complies with POSIX standard. After this change, the error is not outputted anymore.