### PR TITLE
Add install instruction for Manjaro

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,12 +33,12 @@ Make sure you have installed *dkms*, *linux headers* and a bluetooth implementat
 
 * On **Arch** and Arch-based distros (like **Antergos**), try  
   `sudo pacman -S dkms linux-headers bluez bluez-utils`  
-* On **Manjaro** try
-  `sudo pacman -S dkms linux-latest-headers bluez bluez-utils`
 * On **Debian** based systems (like Ubuntu) you can install those packages by running  
   ``sudo apt-get install dkms linux-headers-`uname -r` ``  
 * On **Fedora**, it is  
   ``sudo dnf install dkms make bluez bluez-tools kernel-devel-`uname -r` kernel-headers-`uname -r` `` 
+* On **Manjaro** try
+  `sudo pacman -S dkms linux-latest-headers bluez bluez-utils`
 * On **OSMC** you will have to run the following commands  
   ``sudo apt-get install dkms rbp2-headers-`uname -r` ``  
   ``sudo ln -s "/usr/src/rbp2-headers-`uname -r`" "/lib/modules/`uname -r`/build"`` (as a [workaround](https://github.com/osmc/osmc/issues/471))

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ Make sure you have installed *dkms*, *linux headers* and a bluetooth implementat
 
 * On **Arch** and Arch-based distros (like **Antergos**), try  
   `sudo pacman -S dkms linux-headers bluez bluez-utils`  
+* On **Manjaro** try
+  `sudo pacman -S dkms linux-latest-headers bluez bluez-utils`
 * On **Debian** based systems (like Ubuntu) you can install those packages by running  
   ``sudo apt-get install dkms linux-headers-`uname -r` ``  
 * On **Fedora**, it is  


### PR DESCRIPTION
Package for headers have slightly different name for Manjaro (as it was figured in #119). So I suggest to put explicit instruction in the README. 