### PR TITLE
Fix regression of not being able to disable rumbling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,15 @@ received its end of life. If you're having problems with the new features,
 please report that and use the v0.7 branch until that specific bug is fixed.
 
 
+## Breaking Changes
+
+This version removed some module parameters with only partial replacement.
+One of those if `disable_ff` which can no longer be used. Instead, there's
+a new parameter `trigger_rumble_mode` which can disable trigger rumble
+only. The next update will include a new parameter to set rumble attenuation
+to 100% which translates to no rumble at all.
+
+
 ## Headlines:
 
   * dmks, installer: Move etc sources one level up

--- a/configure.sh
+++ b/configure.sh
@@ -15,7 +15,7 @@ CONF_FILE=$(grep -sl '^options hid_xpadneo' /etc/modprobe.d/*.conf | tail -1)
 : "${CONF_FILE:="/etc/modprobe.d/99-xpadneo-options.conf"}"
 
 # Use getopt NOT getopts to parse arguments.
-OPTS=$(getopt -n "$NAME" -o hz:d:f:v:r: -l help,version,combined-z-axis:,disable-ff:,trigger-rumble-damping: -- "$@")
+OPTS=$(getopt -n "$NAME" -o hz:d:f:v:r: -l help,version,combined-z-axis:,disable-ff:,rumble-attenuation: -- "$@")
 
 
 
@@ -42,10 +42,10 @@ function check_param {
             exit 1
         fi
         ;;
-    "trigger_rumble_damping")
-        if [[ "$value" -gt 256 ]] || [[ "$value" -lt 1 ]];
+    "rumble_attenuation")
+        if [[ "$value" -gt 100 ]] || [[ "$value" -lt 0 ]];
         then
-            echo "$NAME: $key: Invalid value! Value must be between 1 and 256."
+            echo "$NAME: $key: Invalid value! Value must be between 0 and 100."
             exit 1
         fi
         ;;
@@ -110,7 +110,7 @@ function parse_args {
     # If line doesn't exist echo all of the defaults.
     mkdir -p "$(dirname "${CONF_FILE}")"
     touch "${CONF_FILE}"
-    echo "options hid_xpadneo disable_ff=0 trigger_rumble_damping=1 trigger_rumble_mode=0 combined_z_axis=n" >> "$CONF_FILE"
+    echo "options hid_xpadneo disable_ff=0 rumble_attenuation=0 trigger_rumble_mode=0 combined_z_axis=n" >> "$CONF_FILE"
   fi
 
   if [[ $1 == "" ]];
@@ -141,8 +141,8 @@ function parse_args {
         shift 2
         ;;
 
-      -r | --trigger-rumble-damping)
-        key='trigger_rumble_damping'
+      -r | --rumble-attenuation)
+        key='rumble_attenuation'
         value="${2#*=}"
         set_param "$key" "$value"
         shift 2

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,9 +9,15 @@ files in `/sys/module/hid_xpadneo/parameters`:
   * `0` rumbles triggers by pressure and current rumble effect
   * `1` rumbles triggers by force direction (non-conformant)
   * `2` disables trigger rumble
-* `trigger_rumble_damping` (default `4`)
-  * Damp the strength of the trigger force feedback
-  * `1` (none) to `256` (max)
+* `rumble_attenuation` (default `0,0`)
+  * Attenuation the strength of the force feedback
+  * `0` (none, full rumble) to `100` (max, no rumble)
+  * If one or two values are given, the first value is the overall attenuation
+  * If two values are given, the second value applies an extra attenuation to the triggers
+  * Example 1: `0,100` turns trigger rumble off, `100,0` or `100` turn all rumble off
+  * Example 2: `50,50` makes 50% rumble overall, and 25% for the triggers (50% of 50% = 25%)
+  * Example 3: `50` makes 50% rumble overall (main and triggers)
+  * Trigger-only rumble is not possible
 * `combined_z_axis` (default `n`)
   * Combine the triggers (`ABS_Z` and `ABS_RZ`) to form a single axis `ABS_Z` which is used e.g. in flight simulators
   * The left and right trigger will work against each other.

--- a/docs/config_help
+++ b/docs/config_help
@@ -1,5 +1,5 @@
 configure.sh Usage:
-NOTE: Short options don't require an equals sign, only long options.  EX. -r 3 vs. --trigger-rumble-damping=3
+NOTE: Short options don't require an equals sign, only long options.  EX. -r 3 vs. --rumble-attenuation=50
 
 -h, --help
 	Display this help screen.
@@ -10,8 +10,8 @@ NOTE: Short options don't require an equals sign, only long options.  EX. -r 3 v
 -f, --disable-ff
 	Disable the force feedback (Rumble).  [0 (enable all), 1 (disable main only), 2 (disable triggers only), 3 (disable all)]
 
--r, --trigger-rumble-damping
-	Damp the strength of the trigger force feedback. [1 (none) to 256 (max)]
+-r, --rumble-attenuation
+	Attenuate the strength of the trigger force feedback. [0 (none, full rumble) to 100 (max, no rumble)]
 
 -z, --combined-z-axis
 	Combine the triggers (ABS_Z and ABS_RZ) to form a single axis ABS_Z which is used e.g. in


### PR DESCRIPTION
This is not actually a fix but a replacement through a new feature.

Rumble attenuation can now be controller with the `rumble_attenuation` parameter in percent, i.e. putting 100 as the percentage value means full attenuation aka "no rumble at all".