### PR TITLE
hid-xpadneo: Replace `combined_z_axis` with additional axis

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -15,7 +15,7 @@ CONF_FILE=$(grep -sl '^options hid_xpadneo' /etc/modprobe.d/*.conf | tail -1)
 : "${CONF_FILE:="/etc/modprobe.d/99-xpadneo-options.conf"}"
 
 # Use getopt NOT getopts to parse arguments.
-OPTS=$(getopt -n "$NAME" -o hz:d:f:v:r: -l help,version,combined-z-axis:,disable-ff:,rumble-attenuation: -- "$@")
+OPTS=$(getopt -n "$NAME" -o h:f:r: -l help,version,disable-ff:,rumble-attenuation: -- "$@")
 
 
 
@@ -46,13 +46,6 @@ function check_param {
         if [[ "$value" -gt 100 ]] || [[ "$value" -lt 0 ]];
         then
             echo "$NAME: $key: Invalid value! Value must be between 0 and 100."
-            exit 1
-        fi
-        ;;
-    "combined_z_axis")
-        if [[ "$value" != "y" ]] && [[ "$value" != "n" ]];
-        then
-            echo "$NAME: $key: Invalid value! Value must be 'y' or 'n'."
             exit 1
         fi
         ;;
@@ -110,7 +103,7 @@ function parse_args {
     # If line doesn't exist echo all of the defaults.
     mkdir -p "$(dirname "${CONF_FILE}")"
     touch "${CONF_FILE}"
-    echo "options hid_xpadneo disable_ff=0 disable_deadzones=0 rumble_attenuation=0 trigger_rumble_mode=0 combined_z_axis=n" >> "$CONF_FILE"
+    echo "options hid_xpadneo disable_ff=0 disable_deadzones=0 rumble_attenuation=0 trigger_rumble_mode=0" >> "$CONF_FILE"
   fi
 
   if [[ $1 == "" ]];
@@ -143,13 +136,6 @@ function parse_args {
 
       -r | --rumble-attenuation)
         key='rumble_attenuation'
-        value="${2#*=}"
-        set_param "$key" "$value"
-        shift 2
-        ;;
-
-      -z | --combined-z-axis)
-        key='combined_z_axis'
         value="${2#*=}"
         set_param "$key" "$value"
         shift 2

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -21,9 +21,6 @@ files in `/sys/module/hid_xpadneo/parameters`:
   * Example 2: `50,50` makes 50% rumble overall, and 25% for the triggers (50% of 50% = 25%)
   * Example 3: `50` makes 50% rumble overall (main and triggers)
   * Trigger-only rumble is not possible
-* `combined_z_axis` (default `n`)
-  * Combine the triggers (`ABS_Z` and `ABS_RZ`) to form a single axis `ABS_Z` which is used e.g. in flight simulators
-  * The left and right trigger will work against each other.
 * `quirks` (default empty)
   * Let's you adjust the quirk mode of your controller
   * Comma separated list of `address:flags` pairs

--- a/docs/config_help
+++ b/docs/config_help
@@ -13,10 +13,6 @@ NOTE: Short options don't require an equals sign, only long options.  EX. -r 3 v
 -r, --rumble-attenuation
 	Attenuate the strength of the trigger force feedback. [0 (none, full rumble) to 100 (max, no rumble)]
 
--z, --combined-z-axis
-	Combine the triggers (ABS_Z and ABS_RZ) to form a single axis ABS_Z which is used e.g. in
-	flight simulators.  The left and right trigger will work against each other.  [y, n]
-
 
 NOTE: For more information on configuring xpadneo visit https://atar-axis.github.io/xpadneo/
       Or the GitHub page: https://github.com/atar-axis/xpadneo


### PR DESCRIPTION
Instead of combining both axis and thus removing the original trigger
function, we can expose a synthesized axis that is built from both the
triggers combined.

See-also: https://github.com/atar-axis/xpadneo/issues/63
Closes: https://github.com/atar-axis/xpadneo/issues/221
Signed-off-by: Kai Krakow <kai@kaishome.de>