### PR TITLE
xpadneo, udev: Work around libinput using the controller as touchpad

### DIFF
--- a/hid-xpadneo/etc-udev-rules.d/98-xpadneo.rules
+++ b/hid-xpadneo/etc-udev-rules.d/98-xpadneo.rules
@@ -1,2 +1,2 @@
 ACTION=="add", KERNEL=="0005:045E:02FD.*|0005:045E:02E0.*|0005:045E:0B05.*", SUBSYSTEM=="hid", DRIVER!="xpadneo", ATTR{driver/unbind}="%k", ATTR{[drivers/hid:xpadneo]bind}="%k"
-ACTION=="add", DRIVERS=="xpadneo", SUBSYSTEM=="input", TAG+="uaccess", MODE="0664"
+ACTION=="add", DRIVERS=="xpadneo", SUBSYSTEM=="input", ENV{ID_INPUT_JOYSTICK}=="1", TAG+="uaccess", MODE="0664", ENV{LIBINPUT_IGNORE_DEVICE}="1"


### PR DESCRIPTION
This is a bug in the `libinput` device class detection and would create
an error log per pressed button. We can force `libinput` to ignore the
controller but this does not fix the underlying bug. But it also seems
to introduce no regressions: The Xbox logo button still works.

Fixes: https://github.com/atar-axis/xpadneo/issues/205
Signed-off-by: Kai Krakow <kai@kaishome.de>