### PR TITLE
Rework dead zone handling

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -110,7 +110,7 @@ function parse_args {
     # If line doesn't exist echo all of the defaults.
     mkdir -p "$(dirname "${CONF_FILE}")"
     touch "${CONF_FILE}"
-    echo "options hid_xpadneo disable_ff=0 rumble_attenuation=0 trigger_rumble_mode=0 combined_z_axis=n" >> "$CONF_FILE"
+    echo "options hid_xpadneo disable_ff=0 disable_deadzones=0 rumble_attenuation=0 trigger_rumble_mode=0 combined_z_axis=n" >> "$CONF_FILE"
   fi
 
   if [[ $1 == "" ]];

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,6 +5,9 @@
 The driver can be reconfigured at runtime by accessing the following sysfs
 files in `/sys/module/hid_xpadneo/parameters`:
 
+* `disable_deadzones` (default `0`)
+  * `0` enables standard behavior to be compatible with `joydev` expectations
+  * `1` enables raw passthrough of axis values without dead zones for high-precision use with modern Wine/Proton games
 * `trigger_rumble_mode` (default `0`)
   * `0` rumbles triggers by pressure and current rumble effect
   * `1` rumbles triggers by force direction (non-conformant)

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ These other projects may not support some of the advanced features of xpadneo.
 * Easy Installation
 * Agile Support and Development
 * Supports customization through profiles
+* Optional high-precision mode for Wine/Proton users
 
 
 ### Xbox One S Wireless controller

--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -911,6 +911,7 @@ static int xpadneo_raw_event(struct hid_device *hdev, struct hid_report *report,
 static int xpadneo_input_configured(struct hid_device *hdev, struct hid_input *hi)
 {
 	struct xpadneo_devdata *xdata = hid_get_drvdata(hdev);
+	int deadzone = 3072, abs_min = 0, abs_max = 65535;
 
 	xdata->idev = hi->input;
 
@@ -950,19 +951,25 @@ static int xpadneo_input_configured(struct hid_device *hdev, struct hid_input *h
 
 	if (param_gamepad_compliance) {
 		hid_info(hdev, "enabling compliance with Linux Gamepad Specification\n");
-		input_set_abs_params(xdata->idev, ABS_X, -32768, 32767, 255, 4095);
-		input_set_abs_params(xdata->idev, ABS_Y, -32768, 32767, 255, 4095);
-		input_set_abs_params(xdata->idev, ABS_RX, -32768, 32767, 255, 4095);
-		input_set_abs_params(xdata->idev, ABS_RY, -32768, 32767, 255, 4095);
+		abs_min = -32768;
+		abs_max = 32767;
 	}
+
+	input_set_abs_params(xdata->idev, ABS_X, abs_min, abs_max, 32, deadzone);
+	input_set_abs_params(xdata->idev, ABS_Y, abs_min, abs_max, 32, deadzone);
+	input_set_abs_params(xdata->idev, ABS_RX, abs_min, abs_max, 32, deadzone);
+	input_set_abs_params(xdata->idev, ABS_RY, abs_min, abs_max, 32, deadzone);
 
 	if (param_combined_z_axis) {
 		/*
 		 * We also need to translate the incoming events to fit within
 		 * the new range, we will do that in the xpadneo_event() hook.
 		 */
-		input_set_abs_params(xdata->idev, ABS_Z, -1023, 1023, 3, 63);
+		input_set_abs_params(xdata->idev, ABS_Z, -1023, 1023, 4, 0);
 		__clear_bit(ABS_RZ, xdata->idev->absbit);
+	} else {
+		input_set_abs_params(xdata->idev, ABS_Z, 0, 1023, 4, 0);
+		input_set_abs_params(xdata->idev, ABS_RZ, 0, 1023, 4, 0);
 	}
 
 	return 0;

--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -76,6 +76,12 @@ MODULE_PARM_DESC(gamepad_compliance,
 		 "(bool) Adhere to Linux Gamepad Specification by using signed axis values. "
 		 "1: enable, 0: disable.");
 
+static bool param_disable_deadzones = 0;
+module_param_named(disable_deadzones, param_disable_deadzones, bool, 0444);
+MODULE_PARM_DESC(disable_deadzones,
+		 "(bool) Disable dead zone handling for raw processing by Wine/Proton, confuses joydev. "
+		 "0: disable, 1: enable.");
+
 #define XPADNEO_QUIRK_NO_PULSE          1
 #define XPADNEO_QUIRK_NO_TRIGGER_RUMBLE 2
 #define XPADNEO_QUIRK_NO_MOTOR_MASK     4
@@ -947,6 +953,11 @@ static int xpadneo_input_configured(struct hid_device *hdev, struct hid_input *h
 			 "(changed PID from 0x%04X to 0x02E0)\n", (u16)xdata->idev->id.product);
 		xdata->idev->id.product = 0x02E0;
 		break;
+	}
+
+	if (param_disable_deadzones) {
+		hid_warn(hdev, "disabling dead zones\n");
+		deadzone = 0;
 	}
 
 	if (param_gamepad_compliance) {


### PR DESCRIPTION
Evidence shows that there is a problematic code path between the Linux kernel and games when using Wine/Proton. Windows games do not expect the input drivers to have dead zones applied but Linux drivers imply that at every level. Since Wine/Proton uses SDL for creating a bus device, it will see a game controller with dead zones already handled - which games do not expect.

This series of commits shrinks the default dead zones and fuzz filter for more precision and adds a kill switch for disabling handling of dead zones completely so Wine/Proton games will have their expectations fulfilled.