### PR TITLE
docs: Replace Ko-fi link to attribute donations to current maintainer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-[![ko-fi](https://www.ko-fi.com/img/donate_sm.png)](https://ko-fi.com/R6R5P6FN)
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/O4O43SURE)
 If you want to support me or accelerate the development of a special feature, consider a small donation :heart:
 Just leave a message if your donation is for a specific use (like a new hardware or a specific function).
 


### PR DESCRIPTION
This replaces the Ko-fi link to attribute new donations to the current maintainer Kai Krakow instead of Florian Dollinger, suggested and requested by Florian.