### PR TITLE
Add support for XB1S BLE firmware update

### DIFF
--- a/hid-xpadneo/etc-modprobe.d/xpadneo.conf
+++ b/hid-xpadneo/etc-modprobe.d/xpadneo.conf
@@ -2,3 +2,4 @@ alias hid:b0005g*v0000045Ep000002E0 hid_xpadneo
 alias hid:b0005g*v0000045Ep000002FD hid_xpadneo
 alias hid:b0005g*v0000045Ep00000B05 hid_xpadneo
 alias hid:b0005g*v0000045Ep00000B13 hid_xpadneo
+alias hid:b0005g*v0000045Ep00000B20 hid_xpadneo

--- a/hid-xpadneo/etc-udev-rules.d/60-xpadneo.rules
+++ b/hid-xpadneo/etc-udev-rules.d/60-xpadneo.rules
@@ -1,5 +1,5 @@
 # Rebind driver to xpadneo
-ACTION=="bind", SUBSYSTEM=="hid", DRIVER!="xpadneo", KERNEL=="0005:045E:*", KERNEL=="*:02FD.*|*:02E0.*|*:0B05.*|*:0B13.*", ATTR{driver/unbind}="%k", ATTR{[drivers/hid:xpadneo]bind}="%k"
+ACTION=="bind", SUBSYSTEM=="hid", DRIVER!="xpadneo", KERNEL=="0005:045E:*", KERNEL=="*:02FD.*|*:02E0.*|*:0B05.*|*:0B13.*|*:0B20.*", ATTR{driver/unbind}="%k", ATTR{[drivers/hid:xpadneo]bind}="%k"
 
 # Tag xpadneo devices for access in the user session
 ACTION=="add|change", DRIVERS=="xpadneo", SUBSYSTEM=="input", TAG+="uaccess"

--- a/hid-xpadneo/etc-udev-rules.d/60-xpadneo.rules
+++ b/hid-xpadneo/etc-udev-rules.d/60-xpadneo.rules
@@ -1,2 +1,5 @@
-ACTION=="add", KERNEL=="0005:045E:02FD.*|0005:045E:02E0.*|0005:045E:0B05.*|0005:045E:0B13.*", SUBSYSTEM=="hid", DRIVER!="xpadneo", ATTR{driver/unbind}="%k", ATTR{[drivers/hid:xpadneo]bind}="%k"
+# Rebind driver to xpadneo
+ACTION=="bind", SUBSYSTEM=="hid", DRIVER!="xpadneo", KERNEL=="0005:045E:*", KERNEL=="*:02FD.*|*:02E0.*|*:0B05.*|*:0B13.*", ATTR{driver/unbind}="%k", ATTR{[drivers/hid:xpadneo]bind}="%k"
+
+# Tag xpadneo devices for access in the user session
 ACTION=="add|change", DRIVERS=="xpadneo", SUBSYSTEM=="input", TAG+="uaccess"

--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -1159,6 +1159,9 @@ static int xpadneo_probe(struct hid_device *hdev, const struct hid_device_id *id
 	 * 0xB12 Dongle, USB Windows and USB Linux mode
 	 * 0xB13 wireless Linux mode (Android mode)
 	 *
+	 * Xbox Controller BLE mode:
+	 * 0xB20 wireless BLE mode
+	 *
 	 * TODO: We should find a better way of doing this so SDL2 could
 	 * still detect our driver as the correct model. Currently this
 	 * maps all controllers to the same model.
@@ -1174,6 +1177,7 @@ static int xpadneo_probe(struct hid_device *hdev, const struct hid_device_id *id
 		break;
 	case 0x0B05:
 	case 0x0B13:
+	case 0x0B20:
 		hdev->product = 0x02E0;
 		hdev->version = 0x00000903;
 		break;
@@ -1253,6 +1257,8 @@ static const struct hid_device_id xpadneo_devices[] = {
 	/* XBOX ONE S / X */
 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, 0x02FD) },
 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, 0x02E0) },
+	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, 0x0B20),
+	 .driver_data = XPADNEO_QUIRK_SHARE_BUTTON },
 
 	/* XBOX ONE Elite Series 2 */
 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, 0x0B05) },


### PR DESCRIPTION
Microsoft added BLE support to existing controllers.

This PR adds support for binding xpadneo to controllers flashed with the new firmware version which exposes the device under a new PID. It is still work in progress as we may add mapping fixups and quirk handling.