### PR TITLE
xpadneo, hidraw: Also work around SDL2 hidraw mode conflicts

### DIFF
--- a/hid-xpadneo/etc-udev-rules.d/50-xpadneo-fixup-steamlink.rules
+++ b/hid-xpadneo/etc-udev-rules.d/50-xpadneo-fixup-steamlink.rules
@@ -1,2 +1,2 @@
 #FIXME(issue-291) Work around Steamlink not properly detecting the mappings
-ACTION=="add|change", DRIVERS=="xpadneo", SUBSYSTEM=="hidraw", MODE:="0600"
+ACTION=="add|change", DRIVERS=="xpadneo", SUBSYSTEM=="hidraw", MODE:="0000"


### PR DESCRIPTION
Also fixes Steam Input which apparently also uses SDL2.

The bug shows up when SDL identifies the controller as being on USB
instead of Bluetooth (SDL Gamepad ID starts with `03` instead of `05`)
which then messes with SDL's expectations for the contents of hidraw.

This fixes two SDL problems:

  * Wrong mappings in hidraw (buttons shifted to other buttons)
  * SDL2 doesn't properly throttle rumble commands (endless rumble)

See-also: https://github.com/atar-axis/xpadneo/issues/286
Maybe-fixes: https://github.com/atar-axis/xpadneo/issues/303
Maybe-fixes: https://github.com/atar-axis/xpadneo/issues/311
Maybe-fixes: https://github.com/atar-axis/xpadneo/issues/314
Signed-off-by: Kai Krakow <kai@kaishome.de>