### PR TITLE
dkms: Explicitly add version to the install phase

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ if [[ -z "${INSTALLED[*]}" ]]; then
     cp --recursive hid-xpadneo/. "/usr/src/hid-xpadneo-${VERSION}/."
 
     echo "* installing module (using DKMS)"
-    dkms install "${V[*]}" "hid-xpadneo" --force || cat_dkms_make_log
+    dkms install "${V[*]}" "hid-xpadneo/${VERSION}" --force || cat_dkms_make_log
 
 else
 

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ if [[ -z "${INSTALLED[*]}" ]]; then
     # TODO: Works around https://github.com/dell/dkms/issues/177 for DKMS 3
     echo "* adding hid-xpadneo-${VERSION} folder to /usr/src"
     mkdir -p "/usr/src/hid-xpadneo-${VERSION}"
-    cp --recursive hid-xpadneo/. "/usr/src/hid-xpadneo-${VERSION}/."
+    cp --recursive "${V[@]}" hid-xpadneo/. "/usr/src/hid-xpadneo-${VERSION}/."
 
     echo "* installing module (using DKMS)"
     dkms install "${V[*]}" "hid-xpadneo/${VERSION}" --force || cat_dkms_make_log

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,11 @@ if [[ -z "${INSTALLED[*]}" ]]; then
     echo "* creating dkms.conf"
     sed 's/"@DO_NOT_CHANGE@"/"'"${VERSION}"'"/g' <hid-xpadneo/dkms.conf.in >hid-xpadneo/dkms.conf
 
+    # TODO: Works around https://github.com/dell/dkms/issues/177 for DKMS 3
+    echo "* adding hid-xpadneo-${VERSION} folder to /usr/src"
+    mkdir -p "/usr/src/hid-xpadneo-${VERSION}"
+    cp --recursive hid-xpadneo/. "/usr/src/hid-xpadneo-${VERSION}/."
+
     echo "* installing module (using DKMS)"
     dkms install "${V[*]}" "hid-xpadneo" --force || cat_dkms_make_log
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -20,5 +20,5 @@ do
     dkms remove "${V[*]}" "hid-xpadneo/${instance}" --all
 
     echo "  * removing $instance folder from /usr/src"
-    rm --recursive "/usr/src/hid-xpadneo-$instance/"
+    rm --recursive "${V[@]}" "/usr/src/hid-xpadneo-$instance/"
 done


### PR DESCRIPTION
DKMS 3 requires passing the version to BOTH the install and uninstall phase and we omitted it from the install phase.