### PR TITLE
README.md: Fedora instructions are incorrect

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -214,7 +214,7 @@ daemon.
 * On **Debian** based systems (like Ubuntu) you can install those packages by running
   ``sudo apt-get install dkms linux-headers-`uname -r` ``
 * On **Fedora**, it is
-  ``sudo dnf install dkms make bluez bluez-tools kernel-devel-`uname -r` kernel-headers-`uname -r` ``
+  ``sudo dnf install dkms make bluez bluez-tools kernel-devel-`uname -r` kernel-headers ``
 * On **Manjaro** try
   `sudo pacman -S dkms linux-latest-headers bluez bluez-utils`
 * On **openSUSE** (tested on Tumbleweed, should work for Leap), it is


### PR DESCRIPTION
Fedora does not build a `kernel-headers` package for each release of the kernel, so you can't just use `uname -r` to install it.  Installing just the `kernel-headers` package is sufficient.  This is slightly confusing to people coming from other distros.  The `kernel-headers` package only includes files used to build userspace software, so it doesn't need to track the kernel closely.

The `kernel-devel` does track the kernel, so that is appropriate to install using `uname -r`.