### PR TITLE
hid-xpadneo, Makefile: remove requirement for kernel sources

### DIFF
--- a/hid-xpadneo/Makefile
+++ b/hid-xpadneo/Makefile
@@ -1,5 +1,7 @@
-KERNEL_SOURCE_DIR := /usr/src/linux
-LD := ld.bfd
+ifndef KERNEL_SOURCES
+	KERNEL_UNAME ?= $(shell uname -r)
+	KERNEL_SOURCES := /lib/modules/$(KERNEL_UNAME)/build
+endif
 
 all: modules
 
@@ -9,7 +11,7 @@ all: modules
 	git describe --tags --dirty >$@
 
 clean modules modules_install: ../VERSION
-	$(MAKE) -C $(KERNEL_SOURCE_DIR) INSTALL_MOD_DIR="kernel/drivers/hid" LD=$(LD) M=$(shell pwd)/src VERSION="$(shell cat ../VERSION)" $@
+	$(MAKE) -C $(KERNEL_SOURCES) INSTALL_MOD_DIR="kernel/drivers/hid" M="$(shell pwd)/src" VERSION=$(shell cat ../VERSION) $@
 
 reinstall: modules
 	sudo make modules_install


### PR DESCRIPTION
remove the need for needing kernel sources for building and installing xpadneo. when i first found this project i was very weirded by the fact that it required the kernel sources, when many modules i know only need the header files, or modules directory.

i can add the ability to use kernel sources if required, automatically via sourching kernel's Kbuild.

i've also changed it so that `VERSION` isn't a requirement, and can be set at runtime `make VERSION=bleh`, for package builds that don't have access to a git directory.