### PR TITLE
Add configuration for disabling chords

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,6 +33,10 @@ files in `/sys/module/hid_xpadneo/parameters`:
     * `16` if your controller boots in Linux mode (auto-detected, do not change manually)
     * `32` if you prefer to use Nintendo button mappings (i.e., 8BitDo controllers, defaults to off)
     * `64` if your controller has a awkwardly mapped Share button (auto-detected, do not set manually)
+* 'disable_shift_mode' (default 0)
+  * Let's you disable the button chords used with the XBOX button
+  * '0' Xbox logo button will be used as shift
+  * '1' will pass through the Xbox logo button as is
 
 Some settings may need to be changed at loading time of the module, take a look at the following example to see how
 that works:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,7 +34,7 @@ files in `/sys/module/hid_xpadneo/parameters`:
     * `32` if you prefer to use Nintendo button mappings (i.e., 8BitDo controllers, defaults to off)
     * `64` if your controller has a awkwardly mapped Share button (auto-detected, do not set manually)
 * 'disable_shift_mode' (default 0)
-  * Let's you disable the button chords used with the XBOX button
+  * Let's you disable Xbox logo button shift behavior
   * '0' Xbox logo button will be used as shift
   * '1' will pass through the Xbox logo button as is
 

--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -46,6 +46,12 @@ MODULE_PARM_DESC(disable_deadzones,
 		 "(bool) Disable dead zone handling for raw processing by Wine/Proton, confuses joydev. "
 		 "0: disable, 1: enable.");
 
+static bool param_disable_shift_mode = 0;
+module_param_named(disable_shift_mode, param_disable_shift_mode, bool, 0644);
+MODULE_PARAM_DESC(disable_shift_mode,
+		"(bool) Disable use Xbox logo button as shift. Will prohibit profile switching when enabled. "
+		"0: disable, 1: enable.");
+
 static struct {
 	char *args[17];
 	unsigned int nargs;
@@ -931,7 +937,7 @@ static int xpadneo_event(struct hid_device *hdev, struct hid_field *field,
 			xdata->last_abs_rz = value;
 			goto combine_z_axes;
 		}
-	} else if ((usage->type == EV_KEY) && (usage->code == BTN_XBOX)) {
+	} else if (!param_disable_shift_mode && (usage->type == EV_KEY) && (usage->code == BTN_XBOX)) {
 		/*
 		 * Handle the Xbox logo button: We want to cache the button
 		 * down event to allow for profile switching. The button will


### PR DESCRIPTION
For use with steam, the button chord guide + A is mapped to the QAM. To not lose the profile switching behavior let the user configure this.

closes #419 