### PR TITLE
bluez-tools isn't required on Tumbleweed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -256,7 +256,7 @@ daemon.
 * On **Manjaro** try
   `sudo pacman -S dkms linux-latest-headers bluez bluez-utils`
 * On **openSUSE** (tested on Tumbleweed, should work for Leap), it is
-  `sudo zypper install dkms make bluez bluez-tools kernel-devel kernel-source`
+  `sudo zypper install dkms make bluez kernel-devel kernel-source`
 * On **OSMC** you will have to run the following commands
   ``sudo apt-get install dkms rbp2-headers-`uname -r` ``
   ``sudo ln -s "/usr/src/rbp2-headers-`uname -r`" "/lib/modules/`uname -r`/build"`` (as a [workaround](https://github.com/osmc/osmc/issues/471))


### PR DESCRIPTION
Just a quick update to remove a package that doesn't exist anymore: https://software.opensuse.org/search?q=bluez-tools&baseproject=openSUSE%3AFactory

I was able to install the kernel module and play with my controller just fine with no substitute, I believe these tools have been rolled into the main `bluez` package now. 