### PR TITLE
core, quirks: Add GameSir T4 Nova Lite support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -191,6 +191,21 @@ options hid_xpadneo quirks=A0:5A:5D:xx:xx:xx+2
 This controller uses emulated profile switching support (see below).
 
 
+### GameSir T4 Nova Lite Family
+
+This driver supports the GameSir T4 Nova Lite controller family, tested by the community. These models have a quirk of
+only allowing rumble when all motor-enable bits are set and does not have trigger rumble motors. It looks like these
+models are available with different MAC OUIs, so your particular controller may not be automatically detected. In this
+case, manually add the quirk flags for your controller:
+
+```
+# /etc/modprobe.conf
+options hid_xpadneo quirks=3E:42:6C:xx:xx:xx+6
+```
+
+This controller uses emulated profile switching support (see below).
+
+
 ## Profile Switching
 
 The driver supports switching between different profiles, either through emulation or by using the hardware

--- a/docs/README.md
+++ b/docs/README.md
@@ -205,6 +205,8 @@ options hid_xpadneo quirks=3E:42:6C:xx:xx:xx+6
 
 This controller uses emulated profile switching support (see below).
 
+This manufacturer uses random MAC addresses, so we cannot rely on known OUIs. Heuristics try to detect this controller.
+
 
 ## Profile Switching
 

--- a/docs/heuristics/gamesir-nova.md
+++ b/docs/heuristics/gamesir-nova.md
@@ -1,0 +1,11 @@
+# GameSir Nova OUIs
+
+Gamesir Nova uses random MAC OUIs. We collect them here to implement a
+working heuristic matcher.
+
+| OUI          | Bit representation                      | descriptor length
+| ------------ | --------------------------------------- | -----------------
+| 3E:42:6C     |   `0011 1110 : 0100 0010 : 0110 1100`   | 283
+| ED:BC:9A     |   `1110 1101 : 1011 1100 : 1001 1010`   | 283
+| 6A:07:14     |   `0110 1010 : 0000 0111 : 0001 0100`   | 283
+| **AND mask** | **`0010 1000 : 0000 0000 : 0000 0000`** | **mask 0x28**

--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -98,11 +98,17 @@ struct quirk {
 };
 
 static const struct quirk xpadneo_quirks[] = {
+	DEVICE_OUI_QUIRK("3E:42:6C",
+			 XPADNEO_QUIRK_NO_PULSE | XPADNEO_QUIRK_NO_MOTOR_MASK |
+			 XPADNEO_QUIRK_NO_TRIGGER_RUMBLE),
 	DEVICE_OUI_QUIRK("98:B6:EA",
 			 XPADNEO_QUIRK_NO_PULSE | XPADNEO_QUIRK_NO_TRIGGER_RUMBLE |
 			 XPADNEO_QUIRK_REVERSE_MASK),
 	DEVICE_OUI_QUIRK("A0:5A:5D", XPADNEO_QUIRK_NO_HAPTICS),
 	DEVICE_OUI_QUIRK("E4:17:D8", XPADNEO_QUIRK_NO_HAPTICS | XPADNEO_QUIRK_NO_TRIGGER_RUMBLE),
+	DEVICE_OUI_QUIRK("ED:BC:9A",
+			 XPADNEO_QUIRK_NO_PULSE | XPADNEO_QUIRK_NO_MOTOR_MASK |
+			 XPADNEO_QUIRK_NO_TRIGGER_RUMBLE),
 };
 
 struct usage_map {
@@ -270,9 +276,9 @@ static void xpadneo_ff_worker(struct work_struct *work)
 
 	spin_unlock_irqrestore(&xdata->ff_lock, flags);
 
-	/* do not send these bits if not supported */
+	/* set all bits if not supported (some clones require these set) */
 	if (unlikely(xdata->quirks & XPADNEO_QUIRK_NO_MOTOR_MASK))
-		r->ff.enable = 0;
+		r->ff.enable = FF_RUMBLE_ALL;
 
 	/* reverse the bits for trigger and main motors */
 	if (unlikely(xdata->quirks & XPADNEO_QUIRK_REVERSE_MASK))
@@ -401,9 +407,10 @@ static void xpadneo_welcome_rumble(struct hid_device *hdev)
 	 */
 
 	save = ff_pck.ff.magnitude_weak;
-	if (xdata->quirks & XPADNEO_QUIRK_NO_MOTOR_MASK)
+	if (xdata->quirks & XPADNEO_QUIRK_NO_MOTOR_MASK) {
 		ff_pck.ff.magnitude_weak = 40;
-	else if (xdata->quirks & XPADNEO_QUIRK_REVERSE_MASK)
+		ff_pck.ff.enable = FF_RUMBLE_ALL;
+	} else if (xdata->quirks & XPADNEO_QUIRK_REVERSE_MASK)
 		ff_pck.ff.enable = FF_RUMBLE_LEFT;
 	else
 		ff_pck.ff.enable = FF_RUMBLE_WEAK;
@@ -418,9 +425,10 @@ static void xpadneo_welcome_rumble(struct hid_device *hdev)
 	mdelay(30);
 
 	save = ff_pck.ff.magnitude_strong;
-	if (xdata->quirks & XPADNEO_QUIRK_NO_MOTOR_MASK)
+	if (xdata->quirks & XPADNEO_QUIRK_NO_MOTOR_MASK) {
 		ff_pck.ff.magnitude_strong = 20;
-	else if (xdata->quirks & XPADNEO_QUIRK_REVERSE_MASK)
+		ff_pck.ff.enable = FF_RUMBLE_ALL;
+	} else if (xdata->quirks & XPADNEO_QUIRK_REVERSE_MASK)
 		ff_pck.ff.enable = FF_RUMBLE_RIGHT;
 	else
 		ff_pck.ff.enable = FF_RUMBLE_STRONG;
@@ -440,6 +448,7 @@ static void xpadneo_welcome_rumble(struct hid_device *hdev)
 		if (xdata->quirks & XPADNEO_QUIRK_NO_MOTOR_MASK) {
 			ff_pck.ff.magnitude_left = 10;
 			ff_pck.ff.magnitude_right = 10;
+			ff_pck.ff.enable = FF_RUMBLE_ALL;
 		} else if (xdata->quirks & XPADNEO_QUIRK_REVERSE_MASK) {
 			ff_pck.ff.enable = FF_RUMBLE_MAIN;
 		} else {

--- a/hid-xpadneo/src/xpadneo.h
+++ b/hid-xpadneo/src/xpadneo.h
@@ -68,6 +68,11 @@ do { \
 #define XPADNEO_QUIRK_REVERSE_MASK      128
 
 #define XPADNEO_QUIRK_NO_HAPTICS        (XPADNEO_QUIRK_NO_PULSE|XPADNEO_QUIRK_NO_MOTOR_MASK)
+#define XPADNEO_QUIRK_SIMPLE_CLONE      (XPADNEO_QUIRK_NO_HAPTICS|XPADNEO_QUIRK_NO_TRIGGER_RUMBLE)
+
+/* MAC OUI masks */
+#define XPADNEO_OUI_MASK(oui,mask)    (((oui)&(mask))==(mask))
+#define XPADNEO_OUI_MASK_GAMESIR_NOVA 0x28
 
 /* timing of rumble commands to work around firmware crashes */
 #define XPADNEO_RUMBLE_THROTTLE_DELAY   msecs_to_jiffies(50)


### PR DESCRIPTION
This family of controllers doesn't support trigger rumble but still needs all the motor-enable bits set unconditionally.

Fixes: https://github.com/atar-axis/xpadneo/issues/484