### PR TITLE
(fix): change rules to match systemd v258 onwards

### DIFF
--- a/hid-xpadneo/etc-udev-rules.d/60-xpadneo.rules
+++ b/hid-xpadneo/etc-udev-rules.d/60-xpadneo.rules
@@ -2,4 +2,4 @@
 ACTION=="bind", SUBSYSTEM=="hid", DRIVER!="xpadneo", KERNEL=="0005:045E:*", KERNEL=="*:02FD.*|*:02E0.*|*:0B05.*|*:0B13.*|*:0B20.*|*:0B22.*", ATTR{driver/unbind}="%k", ATTR{[drivers/hid:xpadneo]bind}="%k"
 
 # Tag xpadneo devices for access in the user session
-ACTION=="add|change", DRIVERS=="xpadneo", SUBSYSTEM=="input", TAG+="uaccess"
+ACTION!="remove", DRIVERS=="xpadneo", SUBSYSTEM=="input", TAG+="uaccess"

--- a/hid-xpadneo/etc-udev-rules.d/70-xpadneo-disable-hidraw.rules
+++ b/hid-xpadneo/etc-udev-rules.d/70-xpadneo-disable-hidraw.rules
@@ -1,3 +1,3 @@
 #FIXME(issue-291) Work around Steamlink not properly detecting the mappings
 #FIXME(issue-457) Word around QMK overriding our hidraw rules
-ACTION=="add|change", DRIVERS=="xpadneo", SUBSYSTEM=="hidraw", MODE:="0000", TAG-="uaccess"
+ACTION!="remove", DRIVERS=="xpadneo", SUBSYSTEM=="hidraw", MODE:="0000", TAG-="uaccess"


### PR DESCRIPTION
This change is compatible with previous versions as well. See https://github.com/systemd/systemd/blob/781d9d0789379d1ea1f2ecefb804d41e9c8b6c38/NEWS#L22-L32