### PR TITLE
Add scripts that sign the module for Secure Boot

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -376,6 +376,17 @@ Please feel free to add other distributions as well!
 - If not using DKMS, follow steps above (generic distribution)
 - Done!
 
+#### Sign the module
+
+If Secure Boot is enabled on your machine, your system will not accept to load the unsigned module
+and you may get this kind of error:
+`modprobe: ERROR: could not insert 'hid_xpadneo': Key was rejected by service`.
+You need to sign it:
+
+* If using DKMS, run `sudo ./sign_and_install.sh` in lieu of `install.sh`.
+* For generic distribution, run `cd hid-xpadneo && sudo ./sign_and_install_generic.sh`
+
+You may need to run the scripts twice, with a reboot in-between, according to the output.
 
 ### Connection
 

--- a/hid-xpadneo/Makefile
+++ b/hid-xpadneo/Makefile
@@ -1,9 +1,25 @@
 KVER ?= $(shell uname -r)
+
 INSTALL_MOD_DIR := kernel/drivers/hid
 KERNEL_SOURCE_DIR ?= /lib/modules/$(KVER)/build
 KERNEL_DEST_DIR := /lib/modules/$(KVER)/$(INSTALL_MOD_DIR)
 MOK_DIR ?= /var/lib/shim-signed/mok
+ETC_PREFIX ?= /etc
+DOC_PREFIX ?= /usr/share/doc/xpadneo
+META_PREFIX ?= /usr/share/metainfo
+
 LD := ld.bfd
+MODPROBE_CONFS := xpadneo.conf
+UDEV_RULES := 60-xpadneo.rules 70-xpadneo-disable-hidraw.rules
+DOC_SRCS := ../NEWS.md $(wildcard ../docs/[0-9A-Z]*.md)
+DOCS := $(notdir $(DOC_SRCS))
+
+ifeq ($(PREFIX),)
+  UDEVADM ?= udevadm
+else
+  $(warning Installing to prefix, udevadm commands will not be run!)
+  UDEVADM ?= : SKIPPING udevadm
+endif
 
 all: modules
 
@@ -20,8 +36,28 @@ clean modules modules_install: ../VERSION
 check_sudo:
 	[ "$(shell id -u)" = "0"  ] || { echo >&2 "needs to be run with sudo"; exit 1; }
 
-reinstall: modules check_sudo modules_install unload load
-reinstall-sign: modules check_sudo modules_install sign unload load
+reinstall: modules check_sudo install-all unload load
+reinstall-sign: modules check_sudo install-all sign unload load
+install-all: install install-metainfo
+
+install: modules_install
+	mkdir -p $(PREFIX)$(ETC_PREFIX)/modprobe.d $(PREFIX)$(ETC_PREFIX)/udev/rules.d $(PREFIX)$(DOC_PREFIX)
+	install -D -m 0644 -t $(PREFIX)$(ETC_PREFIX)/modprobe.d $(MODPROBE_CONFS:%=etc-modprobe.d/%)
+	install -D -m 0644 -t $(PREFIX)$(ETC_PREFIX)/udev/rules.d $(UDEV_RULES:%=etc-udev-rules.d/%)
+	install -D -m 0644 -t $(PREFIX)$(DOC_PREFIX) $(DOC_SRCS)
+	$(UDEVADM) control --reload
+
+install-metainfo:
+	install -D -m 0644 -t $(PREFIX)$(META_PREFIX) ../io.github.atar_axis.xpadneo.metainfo.xml
+
+uninstall: check_sudo unload ../VERSION
+	rm -f $(KERNEL_DEST_DIR)/hid-xpadneo.ko*
+	rm -f $(DOCS:%=$(PREFIX)$(DOC_PREFIX)/%)
+	rm -f $(UDEV_RULES:%=$(PREFIX)$(ETC_PREFIX)/udev/rules.d/%)
+	rm -f $(MODPROBE_CONFS:%=$(PREFIX)$(ETC_PREFIX)/modprobe.d/%)
+	rm -f $(PREFIX)$(META_PREFIX)/io.github.atar_axis.xpadneo.metainfo.xml
+	rmdir --ignore-fail-on-non-empty -p $(PREFIX)$(ETC_PREFIX)/modprobe.d $(PREFIX)$(ETC_PREFIX)/udev/rules.d $(PREFIX)$(DOC_PREFIX) || true
+	$(UDEVADM) control --reload
 
 $(MOK_DIR)/MOK.priv $(MOK_DIR)/MOK.der:
 # Create the shim MOK keys if they do not exist, using update-secureboot-policy.
@@ -48,6 +84,7 @@ unload: check_sudo
 	rmmod hid-xpadneo || echo "proceeding anyways"
 
 load: check_sudo
+	depmod -a
 	modprobe hid-xpadneo $(MOD_PARAMS)
 
 # DKMS support rules

--- a/hid-xpadneo/Makefile
+++ b/hid-xpadneo/Makefile
@@ -1,4 +1,8 @@
-KERNEL_SOURCE_DIR ?= /lib/modules/$(shell uname -r)/build
+KVER ?= $(shell uname -r)
+INSTALL_MOD_DIR := kernel/drivers/hid
+KERNEL_SOURCE_DIR ?= /lib/modules/$(KVER)/build
+KERNEL_DEST_DIR := /lib/modules/$(KVER)/$(INSTALL_MOD_DIR)
+MOK_DIR ?= /var/lib/shim-signed/mok
 LD := ld.bfd
 
 all: modules
@@ -11,12 +15,40 @@ all: modules
 # convenience rules for local development
 
 clean modules modules_install: ../VERSION
-	$(MAKE) -C $(KERNEL_SOURCE_DIR) INSTALL_MOD_DIR="kernel/drivers/hid" LD=$(LD) M=$(shell pwd)/src VERSION="$(shell cat ../VERSION)" $@
+	$(MAKE) -C $(KERNEL_SOURCE_DIR) INSTALL_MOD_DIR="$(INSTALL_MOD_DIR)" LD=$(LD) M=$(shell pwd)/src VERSION="$(shell cat ../VERSION)" $@
 
-reinstall: modules
-	sudo make modules_install
-	sudo rmmod hid-xpadneo || true
-	sudo modprobe hid-xpadneo $(MOD_PARAMS)
+check_sudo:
+	[ "$(shell id -u)" = "0"  ] || { echo >&2 "needs to be run with sudo"; exit 1; }
+
+reinstall: modules check_sudo modules_install unload load
+reinstall-sign: modules check_sudo modules_install sign unload load
+
+$(MOK_DIR)/MOK.priv $(MOK_DIR)/MOK.der:
+# Create the shim MOK keys if they do not exist, using update-secureboot-policy.
+# Users have to handle it themselves if it is not installed or not a good version.
+ifeq ($(shell update-secureboot-policy --help 2>&1 | grep 'new-key'),)
+	@echo "update-secureboot-policy not installed or does not have 'new-key' option. You will have to create the MOK yourself in $(MOK_DIR)"
+else
+	make check_sudo
+	@update-secureboot-policy --new-key
+endif
+
+sign: $(MOK_DIR)/MOK.priv $(MOK_DIR)/MOK.der $(KERNEL_DEST_DIR)/hid-xpadneo.ko
+	make check_sudo
+# Enroll the shim MOK public key
+ifeq ($(shell update-secureboot-policy --help 2>&1 | grep 'enroll-key'),)
+	mokutil --import "$(MOK_DIR)/MOK.der"
+else
+	update-secureboot-policy --enroll-key | grep -q --invert-match 'No DKMS modules installed' \
+	  || mokutil --import "$(MOK_DIR)/MOK.der"
+endif
+	$(KERNEL_SOURCE_DIR)/scripts/sign-file sha256 $^
+
+unload: check_sudo
+	rmmod hid-xpadneo || echo "proceeding anyways"
+
+load: check_sudo
+	modprobe hid-xpadneo $(MOD_PARAMS)
 
 # DKMS support rules
 

--- a/hid-xpadneo/sign_and_install_generic.sh
+++ b/hid-xpadneo/sign_and_install_generic.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#set -x
+set -e
+
+# https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/kernel-module-driver-configuration/Working_with_Kernel_Modules/#sect-signing-kernel-modules-for-secure-boot
+
+source "$(dirname "$0")/../lib/mok.sh"
+
+if [ "$EUID" -ne 0 ]
+then error "Please run as root"
+fi
+
+command -v openssl > /dev/null 2>&1 \
+  || warn "missing openssl, you will not be able to create a new MOK key"
+command -v mokutil > /dev/null 2>&1 \
+  || warn "missing mokutil, you will not be able to sign the module"
+
+function install_xpadneo () {
+  info "start install_xpadneo"
+
+  make reinstall-sign
+  # Generic install already loads the module, so no need to use depmod and modprobe
+
+  if modinfo hid-xpadneo
+  then
+    info "finished install_xpadneo"
+
+    if [ -d /sys/module/hid_xpadneo ]
+    then
+      info "hid_xpadneo loaded!"
+      # try to load uhid to support Bluetooth LE (for firmware 5.x)
+      if [ ! -d /sys/devices/virtual/misc/uhid ]
+      then modprobe uhid
+      fi
+    else warn "failed to load hid_xpadneo (check for errors by running 'sudo dmesg')"
+    fi
+  else warn "failed to load hid_xpadneo"
+  fi
+
+  info "finished install_xpadneo"
+}
+
+if [ "$#" -ne "0" ]
+then
+  signing_help
+  exit 0
+else
+  if mokutil --sb-state | grep -q "SecureBoot enabled"; then
+    if ! [ -d /sys/module/hid_xpadneo ]
+    then
+      info "Secure boot is enabled, signing is needed"
+      # Check/enroll keys in default shim directory
+      if check_keys "/var/lib/shim-signed/mok"
+      then install_xpadneo
+      fi
+    else
+      info "hid_xpadneo is loaded"
+    fi
+  else
+    warn "Secure boot is disabled, no need to sign module!"
+    export skip_signing=1
+    if ! [ -d /sys/module/hid_xpadneo ]
+    then install_xpadneo
+    fi
+  fi
+fi

--- a/lib/mok.sh
+++ b/lib/mok.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# set -x
+
+DKMS_DEFAULT_MOK_DIR="/var/lib/dkms"
+UBUNTU_DEFAULT_MOK_DIR="/var/lib/shim-signed/mok"
+USP_MOK_DIR="/var/lib/shim-signed/mok"
+
+if [ ${EUID} -ne 0 ]
+then
+	echo >&2 "ERROR: You most probably need superuser privileges to use this script, \
+please run me via sudo!"
+	exit 3
+fi
+
+function info  { echo -e "\e[32m[info] $*\e[39m"; }
+function warn  { echo -e "\e[33m[warn] $*\e[39m"; }
+function error { echo -e "\e[31m[error] $*\e[39m"; exit 1; }
+
+function signing_help () {
+  echo "
+    just run the script, reboot (you will have to type a pass you set) and run again!
+  "
+}
+
+# Check that Machine Owner Keys exist and are enrolled. Generate new ones if necessary.
+# Accept a parameter for MOK location to check. Otherwise, use configured or default DKMS directory.
+# If it exists, enroll MOK if necessary, but do not create new ones.
+# If no key file found, we generate MOK.
+# Return 0 if key already exists and is enrolled, 1 if it needs a restart to enroll.
+function check_keys () {
+  moks_dir="$1"
+
+  # Load and use values set in DKMS (or Ubuntu) configuration file if no parameter
+  if [ -z "$moks_dir" ]
+  then
+    source /etc/dkms/framework.conf
+    [[ -r /etc/os-release ]] && source /etc/os-release
+
+    # DKMS uses the default key created by update-secureboot-policy for Ubuntu and the likes
+    if [[ -z "${mok_signing_key}" ]] \
+      && { [ "$ID" = "ubuntu" ] || [[ "${ID_LIKE[0]}" == "ubuntu"* ]]; }
+    then
+      echo "Using default MOK key location for Ubuntu and derivatives"
+      moks_dir="$UBUNTU_DEFAULT_MOK_DIR"
+    else
+      # Use MOK location defined in /etc/dkms/framework.conf. Fallback to default one
+      if [ -z "$mok_signing_key" ]
+      then mok_signing_key="$DKMS_DEFAULT_MOK_DIR/mok.key"
+      fi
+      if [ -z "$mok_certificate" ]
+      then mok_certificate="$DKMS_DEFAULT_MOK_DIR/mok.pub"
+      fi
+
+      echo "Using DKMS configured or default MOK files locations"
+      # Check if DKMS key already exists, create it otherwise
+      if [ -f "$mok_signing_key" ] && [ -f "$mok_certificate" ]
+      then
+        # If key is already trusted, no need to enroll it
+        if check_key "$mok_signing_key" "$mok_certificate"
+        then return 0
+        fi
+      else generate_dkms_mok "$mok_signing_key" "$mok_certificate"
+      fi
+
+      # MOK was just created or is not trusted yet
+      enroll_mok "$mok_certificate"
+      return 1
+    fi
+  fi
+
+  # Check if any key is present and enrolled
+  if check_key "$moks_dir/MOK.priv" "$moks_dir/MOK.der" \
+    || check_key "$moks_dir/mok.key" "$moks_dir/mok.pub"
+  then return 0
+  fi
+
+  info "No Private key found or missing associated DER file in $moks_dir. \
+Generating and importing it."
+  # Try to use update-secureboot-policy if the given directory corresponds to where it stores MOK
+  if [ "$USP_DEFAULT_MOK_DIR" = "$moks_dir" ]
+  then
+    generate_usp_mok
+    enroll_usp_mok
+  else
+    echo "Using custom MOK key location"
+    mkdir -p "$moks_dir"
+    generate_mok "$moks_dir/MOK.priv" "$moks_dir/MOK.der"
+    enroll_mok "$1/MOK.der"
+  fi
+  
+  return 1
+}
+
+# Used by check_keys to check MOK is valid
+# returns 0 if key pair exists and is valid, 1 if it does not exist or is not valid
+function check_key () {
+  if [ -f "$1" ] && [ -f "$2" ]
+  then
+    if mokutil --test-key "$2" | grep -q "already enrolled"
+    then
+      info "MOK Key $2 found, already trusted."
+      return 0
+    else
+      info "$2 MOK key exists but is not trusted yet. Importing it."
+      # Enrolling the MOK, even if not necessary
+      enroll_mok "$moks_dir"
+    fi
+  fi
+
+  return 1
+}
+
+# Used by check_keys to generate DKMS MOK files
+function generate_dkms_mok () {
+  # Use DKMS's generate_mok action, fallback on openssl
+  dkms_help_output=$(bash -c 'dkms --help' 2>&1)
+  if command -v dkms >/dev/null 2>&1 \
+    && echo "$dkms_help_output" | grep -q "generate_mok"
+  then
+    echo "Using 'dkms generate_mok' to manage MOK creation"
+    dkms generate_mok
+  else generate_mok "$1" "$2"
+  fi
+}
+
+# Used by check_keys to generate update-secureboot-policy MOK files
+function generate_usp_mok () {
+  # Use update-secureboot-policy by default, fallback on openssl
+  usp_help_output=$(bash -c 'update-secureboot-policy --help' 2>&1)
+  if command -v update-secureboot-policy >/dev/null 2>&1 \
+    && echo "$usp_help_output" | grep -q "new-key"
+  then
+    echo "Using update-secureboot-policy to manage MOK creation"
+    update-secureboot-policy --new-key
+  else generate_mok "$USP_MOK_DIR/MOK.priv" "$USP_MOK_DIR/MOK.der"
+  fi
+}
+
+# Used by check_keys or as fallback of generate_dkms_mok and generate_usp_mok to generate MOK files
+function generate_mok () {
+  mok_key="$1"
+  mok_cert="$2"
+  
+  if command -v openssl >/dev/null 2>&1
+  then
+    echo "Using generic tools to manage MOK creation"
+
+    cn="$(hostname) Secure Boot signature key (xpadneo)"
+    # Max CN length is 64
+    if [ ${#cn} -gt 64 ]
+    then
+      cn=${cn:0:63}
+      cn="$cn…"
+    fi
+
+    openssl \
+      req -new -x509 \
+      -newkey rsa:2048 -keyout "$mok_key" \
+      -outform DER -out "$mok_cert" \
+      -days 36500 \
+      -subj "/CN=$cn/" \
+      -addext "extendedKeyUsage=codeSigning" || error "issue creating cert"
+
+    chmod 600 "$mok_key"
+    chmod 600 "$mok_cert"
+  else
+    echo "openssl not found, cannot generate key and certificate."
+    return
+  fi
+}
+
+# Used by check_keys to enroll MOK files
+function enroll_usp_mok () {
+  # Use update-secureboot-policy by default, fallback using mokutil
+  if command -v update-secureboot-policy >/dev/null 2>&1 \
+    && update-secureboot-policy --help 2>&1 | grep -q "enroll-key" \
+    && ! update-secureboot-policy --enroll-key 2>&1 | grep -q "No DKMS modules installed"
+  then
+    warn "MOK imported, you will need to reboot to enroll it."
+  else
+    enroll_mok "$USP_MOK_DIR/MOK.der"
+  fi
+}
+
+# Used by check_keys to enroll MOK files
+function enroll_mok () {
+  warn "Set a one-time import password. You will have to reboot and type it to enroll the MOK."
+  mokutil --import "$1"
+}

--- a/sign_and_install.sh
+++ b/sign_and_install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#set -x
+set -e
+
+# https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/kernel-module-driver-configuration/Working_with_Kernel_Modules/#sect-signing-kernel-modules-for-secure-boot
+
+source "$(dirname "$0")/lib/mok.sh"
+
+command -v openssl > /dev/null 2>&1 \
+  || warn "missing openssl, you will not be able to create a new MOK key"
+command -v mokutil > /dev/null 2>&1 \
+  || warn "missing mokutil, you will not be able to sign the module"
+
+function install_xpadneo () {
+  info "start install_xpadneo"
+
+  # Uninstall previous version
+  source "$(dirname "$0")/uninstall.sh"
+  source "$(dirname "$0")/install.sh"
+
+  module_ko_file=$(modinfo hid-xpadneo | awk '/^filename:/ { print $2 }')
+  if [ -z "$module_ko_file" ]
+  then error "Module compilation or installation failed"
+  fi
+
+  depmod -a
+
+  if modprobe hid-xpadneo && modinfo hid-xpadneo
+  then
+    info "finished install_xpadneo"
+
+    if [ -d /sys/module/hid_xpadneo ]
+    then
+      info "hid_xpadneo loaded!"
+      # try to load uhid to support Bluetooth LE (for firmware 5.x)
+      if [ ! -d /sys/devices/virtual/misc/uhid ]
+      then modprobe uhid
+      fi
+    else warn "failed to load hid_xpadneo (check for errors by running 'sudo dmesg')"
+    fi
+  else warn "failed to load hid_xpadneo"
+  fi
+}
+
+if [ "$#" -ne "0" ]
+then
+  signing_help
+  exit 0
+else
+  if mokutil --sb-state | grep -q "SecureBoot enabled"
+  then info "Secure boot is enabled, signing is needed"
+  else warn "Secure boot is disabled, no need to sign module!"
+  fi
+
+  if ! [ -d /sys/module/hid_xpadneo ]
+  then
+    # Check in DKMS directory and enroll if a MOK is present
+    info "If you want to use specific key, set mok_signing_key and mok_certificate in " \
+     "/etc/dkms/framework.conf. Otherwise, shim default will be used."
+    if check_keys ""
+    then install_xpadneo
+    fi
+  else info "hid_xpadneo is already loaded"
+  fi
+fi


### PR DESCRIPTION
I created scripts to automate the signing and installation steps required on systems with Secure Boot enabled

- For DKMS: /sign_and_install.sh checks that files configured as MOK for DKMS exist and the MOK is enrolled. If it is not the case, then it creates and/or enroll them using either Ubuntu’s tool or `openssl` (or `dkms`) and `mokutil` commands.
Then it run the install script that should build and sign the module using standard DKMS procedure.
- For generic: /hid-xpadneo/sign_and_install_generic.sh applies the same checks, but on “/var/lib/shim-signed/mok” as MOK files location.
Then it build and install the module using make commands.
- /lib/mok.sh handles MOK checks, creation and enrollment.
- /hid-xpadneo/Makefile has been modified to support signing after building the module. It uses MOK located in “/var/lib/shim-signed/mok”.
- /Makefile is modified to better clean files on uninstall.


<!-- By submitting a contribution, you agree that it is accepted under the project's existing license terms.
     Contributions to the module source code are accepted under GPL-2.0-only. -->

- [x] I agree that my contribution is accepted under the project's existing license terms, and that contributions to
      the module source code are accepted under GPL-2.0-only.
- [x]  My contribution has been created with the help of AI, including prior research with AI chatbots or AI-assisted
reviews and suggestions (e.g. GitHub Copilot PR suggestions). I will not contribute commits with a
Co-authored-by signature of an AI agent because I confirm that my contribution has been verified, reviewed and tested by a human being, and I take full responsibility as the author of the commit using my own Signed-off-by.

(The only AI contribution is the Github Copilot review below)