### PR TITLE
xpadneo: Remove deprecated ida_simple_xx() usage

### DIFF
--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -1223,7 +1223,7 @@ static int xpadneo_probe(struct hid_device *hdev, const struct hid_device_id *id
 	if (xdata == NULL)
 		return -ENOMEM;
 
-	xdata->id = ida_simple_get(&xpadneo_device_id_allocator, 0, 0, GFP_KERNEL);
+	xdata->id = ida_alloc(&xpadneo_device_id_allocator, GFP_KERNEL);
 	xdata->quirks = id->driver_data;
 
 	xdata->hdev = hdev;
@@ -1328,7 +1328,7 @@ static int xpadneo_probe(struct hid_device *hdev, const struct hid_device_id *id
 static void xpadneo_release_device_id(struct xpadneo_devdata *xdata)
 {
 	if (xdata->id >= 0) {
-		ida_simple_remove(&xpadneo_device_id_allocator, xdata->id);
+		ida_free(&xpadneo_device_id_allocator, xdata->id);
 		xdata->id = -1;
 	}
 }


### PR DESCRIPTION
Update to use ida_alloc() and ida_free() in place of the deprecated ida_simple_get() and ida_simple_remove() calls. Linux has removed this API in the v6.18 release candidates. ida_simple_xx() has been deprecated since v5.10 and the new API was introduced in v4.19.

Closes: https://github.com/atar-axis/xpadneo/pull/562

----

This change was based on https://lore.kernel.org/all/2ce706d3242b9d3e4b9c20c0a7d9a8afcf8897ec.1729423829.git.christophe.jaillet@wanadoo.fr/ which updated which API was used for a GPIO driver.

I tested the build against 6.18-rc2 and I see no change in behavior when using my controller.