### PR TITLE
xpadneo, hid: Drop usage of ida_simple* functions

### DIFF
--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -1223,7 +1223,7 @@ static int xpadneo_probe(struct hid_device *hdev, const struct hid_device_id *id
 	if (xdata == NULL)
 		return -ENOMEM;
 
-	xdata->id = ida_simple_get(&xpadneo_device_id_allocator, 0, 0, GFP_KERNEL);
+	xdata->id = ida_alloc(&xpadneo_device_id_allocator, GFP_KERNEL);
 	xdata->quirks = id->driver_data;
 
 	xdata->hdev = hdev;
@@ -1328,7 +1328,7 @@ static int xpadneo_probe(struct hid_device *hdev, const struct hid_device_id *id
 static void xpadneo_release_device_id(struct xpadneo_devdata *xdata)
 {
 	if (xdata->id >= 0) {
-		ida_simple_remove(&xpadneo_device_id_allocator, xdata->id);
+		ida_free(&xpadneo_device_id_allocator, xdata->id);
 		xdata->id = -1;
 	}
 }


### PR DESCRIPTION
ida_alloc() and ida_free() should be preferred to the deprecated ida_simple_get() and ida_simple_remove().