### PR TITLE
fix: replace deprecated ida_simple_* with ida_alloc/free for kernel 6.18+

### DIFF
--- a/hid-xpadneo/src/hid-xpadneo.c
+++ b/hid-xpadneo/src/hid-xpadneo.c
@@ -1223,7 +1223,7 @@ static int xpadneo_probe(struct hid_device *hdev, const struct hid_device_id *id
 	if (xdata == NULL)
 		return -ENOMEM;
 
-	xdata->id = ida_simple_get(&xpadneo_device_id_allocator, 0, 0, GFP_KERNEL);
+	xdata->id = ida_alloc(&xpadneo_device_id_allocator, GFP_KERNEL);
 	xdata->quirks = id->driver_data;
 
 	xdata->hdev = hdev;
@@ -1328,7 +1328,7 @@ static int xpadneo_probe(struct hid_device *hdev, const struct hid_device_id *id
 static void xpadneo_release_device_id(struct xpadneo_devdata *xdata)
 {
 	if (xdata->id >= 0) {
-		ida_simple_remove(&xpadneo_device_id_allocator, xdata->id);
+		ida_free(&xpadneo_device_id_allocator, xdata->id);
 		xdata->id = -1;
 	}
 }


### PR DESCRIPTION
## Summary

The `ida_simple_get()` and `ida_simple_remove()` functions have been removed in Linux kernel 6.18. This causes compilation failure on distributions using kernel 6.18+.

This PR replaces the deprecated functions with their modern equivalents:

| Old Function | New Function |
|--------------|--------------|
| `ida_simple_get(&ida, 0, 0, gfp)` | `ida_alloc(&ida, gfp)` |
| `ida_simple_remove(&ida, id)` | `ida_free(&ida, id)` |

## Compatibility

The replacement functions (`ida_alloc`, `ida_free`) have been available since **kernel 4.19**, so this change is fully backward compatible with all currently supported kernel versions.

## Testing

- **Distribution**: CachyOS
- **Kernel**: 6.18.0-3-cachyos
- **Controller**: Xbox Elite Wireless Controller Series 2
- **Connection**: Bluetooth

Successfully tested pairing, connecting, and using the controller for gameplay.

## References

- Kernel commit removing ida_simple_*: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e79bf1f0c2b7
- ida_alloc documentation: https://www.kernel.org/doc/html/latest/core-api/idr.html