### PR TITLE
Add AppStream metainfo with hardware modalias

### DIFF
--- a/xpadneo.metainfo.xml
+++ b/xpadneo.metainfo.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="driver">
+  <id>xpadneo</id>
+  <name>xpadneo</name>
+  <summary>Advanced Linux Driver for Xbox One Wireless Gamepad</summary>
+  <description>
+    <p>
+      Wireless driver for Xbox One S, Xbox Elite Series 2, and Xbox Series X|S
+      controllers connected via Bluetooth. Supports force feedback, rumble
+      effects, trigger force feedback, battery level indication, and
+      working paddle buttons.
+    </p>
+  </description>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-only</project_license>
+  <url type="homepage">https://github.com/atar-axis/xpadneo</url>
+  <url type="bugtracker">https://github.com/atar-axis/xpadneo/issues</url>
+  <provides>
+    <!-- Xbox One S / X -->
+    <modalias>hid:b0005g*v0000045Ep000002E0*</modalias>
+    <modalias>hid:b0005g*v0000045Ep000002FD*</modalias>
+    <modalias>hid:b0005g*v0000045Ep00000B20*</modalias>
+    <!-- Xbox One Elite Series 2 -->
+    <modalias>hid:b0005g*v0000045Ep00000B05*</modalias>
+    <modalias>hid:b0005g*v0000045Ep00000B22*</modalias>
+    <!-- Xbox Series X|S -->
+    <modalias>hid:b0005g*v0000045Ep00000B13*</modalias>
+  </provides>
+</component>


### PR DESCRIPTION
Adds an AppStream metainfo file with `<modalias>` entries for all supported controllers.

This resolves `appstream-metadata-missing-modalias-provide` warnings from packaging tools like lintian when building distribution packages. The warning occurs because the udev rules use `TAG+="uaccess"` without corresponding AppStream metadata to advertise hardware support.

The metainfo also allows software centers (GNOME Software, KDE Discover) and tools like isenkram on Debian/Ubuntu to automatically suggest installing xpadneo when compatible hardware is detected.

References:
- [AppStream Driver Documentation](https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Driver.html)
- [Debian AppStream Guidelines](https://wiki.debian.org/AppStream/Guidelines)

<!-- By submitting a contribution, you agree that it is accepted under the project's primary license,
     with the additional permission that it may also be distributed under GPL-2.0-only. -->

- [x] I agree that my contribution may be distributed under GPL-2.0-only (in addition to the project's primary license)

---

- [ ] Depends on: https://github.com/atar-axis/xpadneo/pull/577