### PR TITLE
WIP: xpadneo, device: Fix up NUL byte before final End Collection

### DIFF
--- a/hid-xpadneo/src/xpadneo/device.c
+++ b/hid-xpadneo/src/xpadneo/device.c
@@ -92,6 +92,17 @@ const __u8 *xpadneo_device_report_fixup(struct hid_device *hdev, __u8 *rdesc, un
 	if (*rsize >= 2 && rdesc[*rsize - 2] == 0xC0 && rdesc[*rsize - 1] == 0x00) {
 		hid_notice(hdev, "fixing up report descriptor size\n");
 		*rsize -= 1;
+	} else if (*rsize >= 2 && rdesc[*rsize - 2] == 0x00 && rdesc[*rsize - 1] == 0xC0) {
+		/*
+		 * Some firmwares write 0x00 where a second End Collection
+		 * (0xC0) was needed, followed by a correct final 0xC0.
+		 * Replace the 0x00 with 0xC0 so the descriptor ends with two
+		 * End Collections. Do NOT shrink the descriptor: both bytes
+		 * are valid End Collection items and are needed to close the
+		 * two open collections.
+		 */
+		hid_notice(hdev, "fixing up report descriptor NUL before end collection\n");
+		rdesc[*rsize - 2] = 0xC0;
 	}
 
 	/* fixup reported axes for Xbox One S */


### PR DESCRIPTION
Some firmwares write 0x00 where a second End Collection (0xC0) was needed to close a nested collection, followed by a correct final 0xC0. The HID parser then sees an unknown Main item instead of the closing End Collection, breaking descriptor parsing for the affected report.

Replace the stray 0x00 with 0xC0 so the descriptor ends with two valid End Collections. Do not shrink the descriptor: both bytes are required to close the two open collections.

TODO:
- [ ] Needs descriptor dump to find and validate both opening offsets

Link: https://github.com/atar-axis/xpadneo/pull/603

<!-- By submitting a contribution, you agree that it is accepted under the project's existing license terms.
     Contributions to the module source code are accepted under GPL-2.0-only. -->

- [x] I agree that my contribution is accepted under the project's existing license terms, and that contributions to
      the module source code are accepted under GPL-2.0-only.
- [x] My contribution has been created with the help of AI, including prior research with AI chatbots or AI-assisted
      reviews and suggestions (e.g. GitHub Copilot PR suggestions). I will *not* contribute commits with a
      Co-authored-by signature of an AI agent because I confirm that my contribution has been verified, reviewed and
      tested by a human being, and I take full responsibility as the author of the commit using my own Signed-off-by.
- [ ] My contribution has not been created with the help of AI coding agents, prior research with AI chatbots, or any
      other interaction with AI.

@GloriousEggroll Are you able to provide the missing broken descriptor so we can implement this evidence-based?